### PR TITLE
Button and timer disabling.

### DIFF
--- a/activities/Fractionator.activity/css/activity.css
+++ b/activities/Fractionator.activity/css/activity.css
@@ -119,6 +119,10 @@ button:hover {
 	border-color: rgb(112, 207, 215);
 	background-color: rgb(69, 191, 178);
 }
+#check:disabled {
+	background-color: rgb(171, 204, 206);
+	border-color: rgb(137, 174, 171);
+}
 
 #replay {
 	background-color: rgb(52, 127, 239);

--- a/activities/Fractionator.activity/js/script.js
+++ b/activities/Fractionator.activity/js/script.js
@@ -113,22 +113,27 @@ function Timer(){
     this.startTime = 0;
     
     this.animationID = 0;
+    this.running = false;
     
     //Starts the timer
     this.start = function(){
         this.time = 0;
         this.startTime = performance.now();
+        this.running = true;
         this.update();
     };
     //Updates the time and display
     this.update = function(){
-        this.animationID = window.requestAnimationFrame(this.update.bind(this));
-        
-        this.time = ((performance.now() - this.startTime)/1000);
-        this.display.innerHTML = this.time.toFixed(2);
+        if(this.running){
+          this.animationID = window.requestAnimationFrame(this.update.bind(this));
+          
+          this.time = ((performance.now() - this.startTime)/1000);
+          this.display.innerHTML = this.time.toFixed(2);
+        }
     };
     this.stop = function(){
         window.cancelAnimationFrame(this.animationID);
+        this.running = false;
     };
 }
 //Initializes a new timer
@@ -260,6 +265,8 @@ function setUpGame() {
     gameMode = $('input[name=mode]:checked').val();
     var difficulty = $('input[name=difficulty]:checked').val();
     var amount = $('input[name=amount]:checked').val();
+    
+    $("#check").prop("disabled",false);
 	
 	// Variables
 	var newItemsHTML = "";
@@ -399,6 +406,7 @@ function check() {
 	if (correct) {
         
 		document.getElementById("results").innerHTML = "Good Job!";
+        $("#check").prop("disabled",true);
         
         if(gameMode == "timed"){
             timer.stop();


### PR DESCRIPTION
* Timer now has a running value that is true when is running, and false when it is not.
* The Timer skips updating when running is false.
* Fixes(?) the timer running on success error.
-----
* The Check button is disabled on a correct answer.
* The button is renabled at the start of a new game.
* Fixes the error where a player runs the check processing after their time has been displayed. (Fixes #14)
* Tentitive css styling for a disabled button has been added.